### PR TITLE
slack-post-resource `in` method should produce the timestamp file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ Timestamps of Slack messages are used as resource versions. For example, a messa
 
 A timestamp uniquely identifies a message within a channel. See [Slack API](https://api.slack.com/events/message) for details.
 
-## Reading Messages
+## Reading Messages (slack-read-resource)
 
 Usage in a pipeline:
 
@@ -114,7 +114,7 @@ When this configuration sees a message with the text `abc 123` and timestamp `11
 - `text_part2`: `123`
 
 
-## Posting Messages
+## Posting Messages (slack-post-resource)
 
 Usage in a pipeline:
 
@@ -194,3 +194,22 @@ Consider a job with the `get: slack-in` step from the example above followed by 
 This will reply to the message read by the `get` step (since `thread` is the timestamp of the original message), and the reply will read:
 
     Hi abc! I will do 123 right away!
+
+### `get`: Get the timestammp of the last message
+
+
+### Example
+
+Considere the use case where you what only **build** message to be send to the slack channel and all other messages (deploy, analysis, etc) to be send in a thread related to that build.
+
+`slack-out` is used to send message after the build job. In order to send message in the associated thread we use **get** on `slack-out` to collect its timestamp and use another ressource `slack-out-thread` to post the message without changing the version of `slack-out`.
+
+```
+name: deploy
+- get: slack-out
+  passed: [build]
+- put: slack-out-thread
+      params:
+        message:
+            thread_ts: "{{slack-out/timestamp}}"
+```

--- a/post/in/main.go
+++ b/post/in/main.go
@@ -4,10 +4,14 @@ import (
     "os"
     "fmt"
     "encoding/json"
+    "io/ioutil"
+    "path/filepath"
 )
 
 func main() {
     var request map[string]interface{}
+
+    destination := os.Args[1]
 
     {
         err := json.NewDecoder(os.Stdin).Decode(&request)
@@ -18,6 +22,13 @@ func main() {
 
     response := make(map[string]interface{})
     response["version"] = request["version"]
+
+    {
+        err := ioutil.WriteFile(filepath.Join(destination, "timestamp"), []byte(request["version"].(string)) , 0644)
+        if err != nil {
+            fatal("writing timestamp file", err)
+        }
+    }
 
     {
         err := json.NewEncoder(os.Stdout).Encode(&response)

--- a/post/in/main.go
+++ b/post/in/main.go
@@ -6,25 +6,34 @@ import (
     "encoding/json"
     "io/ioutil"
     "path/filepath"
+    "github.com/jleben/slack-chat-resource/utils"
 )
 
 func main() {
-    var request map[string]interface{}
-
+	if len(os.Args) < 2 {
+		println("usage: " + os.Args[0] + " <destination>")
+		os.Exit(1)
+    }
+    
     destination := os.Args[1]
 
-    {
-        err := json.NewDecoder(os.Stdin).Decode(&request)
-        if err != nil {
-            fatal("parsing request", err)
-        }
+    var request utils.InRequest
+
+    err := json.NewDecoder(os.Stdin).Decode(&request)
+    if err != nil {
+        fatal("parsing request", err)
     }
 
-    response := make(map[string]interface{})
-    response["version"] = request["version"]
+    var response utils.InResponse
+    response.Version = request.Version
 
     {
-        err := ioutil.WriteFile(filepath.Join(destination, "timestamp"), []byte(request["version"].(string)) , 0644)
+        fmt.Fprintf(os.Stderr, "The Latest versions is:\n")
+        fmt.Fprintf(os.Stderr, "%s\n", request.Version["timestamp"])
+    }
+
+    {
+        err := ioutil.WriteFile(filepath.Join(destination, "timestamp"), []byte(request.Version["timestamp"]) , 0644)
         if err != nil {
             fatal("writing timestamp file", err)
         }

--- a/post/out/main.go
+++ b/post/out/main.go
@@ -148,7 +148,7 @@ func interpolate(text string, source_dir string) string {
 
 func send(message *utils.OutMessage, request *utils.OutRequest, slack_client *slack.Client) utils.OutResponse {
 
-    _, timestamp, err := slack_client.PostMessage(request.Source.ChannelId, message.Text, message.PostMessageParameters)
+    _, timestamp, err := slack_client.PostMessage(request.Source.ChannelId, slack.MsgOptionText(message.Text, false), slack.MsgOptionAttachments(message.Attachments...))
 
     if err != nil {
         fatal("sending", err)

--- a/post/out/main.go
+++ b/post/out/main.go
@@ -81,12 +81,25 @@ func interpolate_message(message * utils.OutMessage, source_dir string) {
 
     for i := 0; i < len(message.Attachments); i++ {
         attachment := &message.Attachments[i]
+
         attachment.Fallback = interpolate(attachment.Fallback, source_dir)
         attachment.Title = interpolate(attachment.Title, source_dir)
         attachment.TitleLink = interpolate(attachment.TitleLink, source_dir)
         attachment.Pretext = interpolate(attachment.Pretext, source_dir)
         attachment.Text = interpolate(attachment.Text, source_dir)
         attachment.Footer = interpolate(attachment.Footer, source_dir)
+
+        for j := 0; j < len(attachment.Fields); j++ {
+            field := &attachment.Fields[i]
+            field.Title = interpolate(field.Title, source_dir)
+            field.Value = interpolate(field.Value, source_dir)
+        }
+
+        for k := 0; k < len(attachment.Actions); k++ {
+            action := &attachment.Actions[i]
+            action.Text = interpolate(action.Text, source_dir)
+            action.URL = interpolate(action.URL, source_dir)
+        }
     }
 }
 

--- a/post/out/main.go
+++ b/post/out/main.go
@@ -90,13 +90,13 @@ func interpolate_message(message * utils.OutMessage, source_dir string) {
         attachment.Footer = interpolate(attachment.Footer, source_dir)
 
         for j := 0; j < len(attachment.Fields); j++ {
-            field := &attachment.Fields[i]
+            field := &attachment.Fields[j]
             field.Title = interpolate(field.Title, source_dir)
             field.Value = interpolate(field.Value, source_dir)
         }
 
         for k := 0; k < len(attachment.Actions); k++ {
-            action := &attachment.Actions[i]
+            action := &attachment.Actions[k]
             action.Text = interpolate(action.Text, source_dir)
             action.URL = interpolate(action.URL, source_dir)
         }

--- a/post/out/main.go
+++ b/post/out/main.go
@@ -161,7 +161,10 @@ func interpolate(text string, source_dir string) string {
 
 func send(message *utils.OutMessage, request *utils.OutRequest, slack_client *slack.Client) utils.OutResponse {
 
-    _, timestamp, err := slack_client.PostMessage(request.Source.ChannelId, slack.MsgOptionText(message.Text, false), slack.MsgOptionAttachments(message.Attachments...))
+    _, timestamp, err := slack_client.PostMessage(request.Source.ChannelId,
+                                                    slack.MsgOptionText(message.Text, false),
+                                                    slack.MsgOptionAttachments(message.Attachments...),
+                                                    slack.MsgOptionPostMessageParameters(message.PostMessageParameters))
 
     if err != nil {
         fatal("sending", err)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -58,6 +58,7 @@ type OutRequest struct {
 
 type OutMessage struct {
     Text string `json:"text"`
+    Attachments []slack.Attachment `json:"attachments"`
     slack.PostMessageParameters
 }
 


### PR DESCRIPTION
I implemented the feature exposed in https://github.com/jleben/slack-chat-resource/issues/3

On top of that I also improse the interpolation by including Actions and Fields